### PR TITLE
Update cpu instruction definition and asm programs for customasm v0.11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "MK1_CPU/assembler"]
 	path = MK1_CPU/assembler
-	url = git@github.com:vascofazza/customasm.git
+	url = git@github.com:hlorenzi/customasm.git

--- a/MK1_CPU/programs/bubble_sort.asm
+++ b/MK1_CPU/programs/bubble_sort.asm
@@ -1,11 +1,11 @@
 ;--- bubble sort ---
 #include "lib/mk1.cpu"
 
-#bank ".data"
+#bank data
 data: #d8 123, 210, 20, 13, 222, 94, 205, 199, 213, 176, 58, 160, 216, 12, 73, 172, 184, 225, 125, 63, 186, 111, 252, 136, 242, 92, 101, 134, 175, 126, 195, 2, 42, 57, 149, 23, 223, 48, 214, 217
 vector_len = pc - data
 vector: #res vector_len
-#bank ".instr"
+#bank instr
 
 init:
   ;copy vector to tmp array

--- a/MK1_CPU/programs/display_hello_world.asm
+++ b/MK1_CPU/programs/display_hello_world.asm
@@ -1,9 +1,9 @@
 #include "lib/mk1.cpu"
 
-#bank ".data"
-helloworld: #str "Hello, world!\0"
+#bank data
+helloworld: #d "Hello, world!\0"
 
-#bank ".instr"
+#bank instr
 main:
   jal init_display
   ldi $b helloworld

--- a/MK1_CPU/programs/lib/helix.asm
+++ b/MK1_CPU/programs/lib/helix.asm
@@ -2,9 +2,9 @@
 
 SPACE = 32
 
-#bank ".data"
+#bank data
 _ready: #d8 1
-#bank ".instr"
+#bank instr
 
 init_display:
   ldi $a 1

--- a/MK1_CPU/programs/lib/mk1.cpu
+++ b/MK1_CPU/programs/lib/mk1.cpu
@@ -1,96 +1,96 @@
-#bankdef ".instr"
+#bits 8
+
+#bankdef instr
 {
-  #addr 0x00
-  #size 0x100
-  #outp 0x00
+    #addr 0x00
+    #size 0x100
+    #outp 0x00
 }
 
-#bankdef ".data"
+#bankdef data
 {
-  #addr 0x00
-  #size 0x100
-  #outp 0x100
+    #addr 0x00
+    #size 0x100
+    #outp 8 * 0x100
 }
 
-#cpudef
+#subruledef reg
 {
-    #bits 8
-
-    #tokendef reg
-    {
-        $a   = 0
-        $b   = 1
-        $c   = 2
-        $d   = 3
-        $sp  = 4
-        $pc  = 5
-        $out = 6
-    }
-
-    #tokendef alu_op
-    {
-        add = 0
-        sub = 1
-        or  = 2
-        and = 3
-    }
-
-    nop -> 0x00
-    hlt -> 0b01111111
-
-    ldi {dst: reg} 0 -> 0b11 @ 0b01 @ 0b00 @ dst[1:0]
-
-    mov {src: reg} {dst: reg} -> 0b00 @ src[2:0] @ dst[2:0]
-    ldi {dst: reg} {value: i8} -> { assert(value <= 0xff), 0b00 @ 0b111 @ dst[2:0] @ value }
-    out -> 0b00000110
-    out	{value: reg} -> 0b00 @ value[2:0] @ 0b110
-    out {value: i8} -> { assert(value <= 0xff), 0b00 @ 0b111 @ 0b110 @ value }
-
-    j {address: u8} -> { assert(address <= 0xff), 0b00 @ 0b111 @ 3'5 @ address }
-
-    ld {dst: reg} [{addr: reg}] -> 0b01 @ dst[2:0] @ addr[2:0]
-    ld {dst: reg} {address: u8} -> { assert(address <= 0xff), 0b01 @ dst[2:0] @ 0b111 @ address }
-
-    st {src: reg} [{addr: reg}] -> 0b10 @ src[2:0] @ addr[2:0]
-    st {src: reg} {address: u8} -> { assert(address <= 0xff), 0b10 @ src[2:0] @ 0b111 @ address }
-
-    {op: alu_op} {operand_1: reg} {operand_2: reg} -> 0b11 @ op[1:0] @ operand_1[1:0] @ operand_2[1:0]
-    {op: alu_op}i {value: i8} {dst: reg} -> { assert(value <= 0xff), 0b1011 @ op[1:0] @ dst[1:0] @ value }
-
-    not ->	0b01111010
-    rll	->	0b01111101
-    rlr	->	0b01111110
-    sll	->	0b01111011
-    slr	->	0b01111100
-
-    cmp $b -> 0b10101110
-    cmp $c -> 0b01000110
-    cmp $d -> 0b01001110
-    cmp {value: i8} -> { assert(value <= 0xff), 0b10000110 @ value }
-
-    push {data: reg} -> 0b10 @ data[2:0] @ 0b100
-    pop {data: reg} -> 0b01 @ data[2:0] @ 0b100
-    ret -> 0b01 @ 3'5 @ 0b100
-
-    jal {address: u8} -> { assert(address <= 0xff), 0b10 @ 3'5 @ 0b100 @ address }
-    jc	{address: u8} -> { assert(address <= 0xff), 0b00110111 @ address }
-    jz	{address: u8} -> { assert(address <= 0xff), 0b00111111 @ address }
-
-    exr 0	-> 0b01111000
-    exr 1	-> 0b01111001
-
-    exw 0 0	-> 0b00000111
-    exw 0 1	-> 0b00001111
-    exw 0 2 -> 0b10001110
-    exw 0 3 -> 0b10010110
-
-    exw 1 0	-> 0b00010111
-    exw 1 1	-> 0b00011111
-    exw 1 2 -> 0b10011110
-    exw 2 3 -> 0b10100110
-
-    je0	{address: u8} -> { assert(address <= 0xff), 0b00100111 @ address }
-    je1	{address: u8} -> { assert(address <= 0xff), 0b00101111 @ address }
+    $a   => 0
+    $b   => 1
+    $c   => 2
+    $d   => 3
+    $sp  => 4
+    $pc  => 5
+    $out => 6
 }
 
-#bank ".instr"
+#subruledef alu_op
+{
+    add => 0
+    sub => 1
+    or  => 2
+    and => 3
+}
+
+#ruledef cpu
+{
+    nop => 0x00
+    hlt => 0b01111111
+
+    ldi {dst: reg} 0 => 0b11 @ 0b01 @ 0b00 @ dst[1:0]
+
+    mov {src: reg} {dst: reg} => 0b00 @ src[2:0] @ dst[2:0]
+    ldi {dst: reg} {value: i8} => { assert(value <= 0xff), 0b00 @ 0b111 @ dst[2:0] @ value }
+    out => 0b00000110
+    out	{value: reg} => 0b00 @ value[2:0] @ 0b110
+    out {value: i8} => { assert(value <= 0xff), 0b00 @ 0b111 @ 0b110 @ value }
+
+    j {address: u8} => { assert(address <= 0xff), 0b00 @ 0b111 @ 5`3 @ address }
+
+    ld {dst: reg} [{addr: reg}] => 0b01 @ dst[2:0] @ addr[2:0]
+    ld {dst: reg} {address: u8} => { assert(address <= 0xff), 0b01 @ dst[2:0] @ 0b111 @ address }
+
+    st {src: reg} [{addr: reg}] => 0b10 @ src[2:0] @ addr[2:0]
+    st {src: reg} {address: u8} => { assert(address <= 0xff), 0b10 @ src[2:0] @ 0b111 @ address }
+
+    {op: alu_op} {operand_1: reg} {operand_2: reg} => 0b11 @ op[1:0] @ operand_1[1:0] @ operand_2[1:0]
+    {op: alu_op}i {value: i8} {dst: reg} => { assert(value <= 0xff), 0b1011 @ op[1:0] @ dst[1:0] @ value }
+
+    not =>	0b01111010
+    rll	=>	0b01111101
+    rlr	=>	0b01111110
+    sll	=>	0b01111011
+    slr	=>	0b01111100
+
+    cmp $b => 0b10101110
+    cmp $c => 0b01000110
+    cmp $d => 0b01001110
+    cmp {value: i8} => { assert(value <= 0xff), 0b10000110 @ value }
+
+    push {data: reg} => 0b10 @ data[2:0] @ 0b100
+    pop {data: reg} => 0b01 @ data[2:0] @ 0b100
+    ret => 0b01 @ 5`3 @ 0b100
+
+    jal {address: u8} => { assert(address <= 0xff), 0b10 @ 5`3 @ 0b100 @ address }
+    jc	{address: u8} => { assert(address <= 0xff), 0b00110111 @ address }
+    jz	{address: u8} => { assert(address <= 0xff), 0b00111111 @ address }
+
+    exr 0	=> 0b01111000
+    exr 1	=> 0b01111001
+
+    exw 0 0	=> 0b00000111
+    exw 0 1	=> 0b00001111
+    exw 0 2 => 0b10001110
+    exw 0 3 => 0b10010110
+
+    exw 1 0	=> 0b00010111
+    exw 1 1	=> 0b00011111
+    exw 1 2 => 0b10011110
+    exw 2 3 => 0b10100110
+
+    je0	{address: u8} => { assert(address <= 0xff), 0b00100111 @ address }
+    je1	{address: u8} => { assert(address <= 0xff), 0b00101111 @ address }
+}
+
+#bank instr

--- a/MK1_CPU/programs/lib/mk1_std.asm
+++ b/MK1_CPU/programs/lib/mk1_std.asm
@@ -23,9 +23,9 @@ multiply: ; $a * $b
   ret
 
 ;--- divide ---
-#bank ".data"
+#bank data
 _sign: #res 1
-#bank ".instr"
+#bank instr
 divide: ;$a / $b
   mov $a $c; c contains tmp value
   ldi $d 2; sign on

--- a/MK1_CPU/programs/merge_sort.asm
+++ b/MK1_CPU/programs/merge_sort.asm
@@ -1,11 +1,11 @@
 ;--- merge sort ---
 #include "lib/mk1.cpu"
 
-#bank ".data"
+#bank data
 data: #d8 123, 210, 20, 13, 222, 94, 205, 199, 213, 176, 58, 160, 216, 12, 73, 172, 184, 225, 125, 63, 186, 111, 252, 136, 242, 92, 101, 134, 175, 126, 195, 2, 42, 57, 149, 23, 223, 48, 214, 217
 vector_len = pc - data
 vector: #res vector_len
-#bank ".instr"
+#bank instr
 
 init:
   jal init_display
@@ -72,13 +72,13 @@ return:
 merge: ;start, mid, end
 
 ; merge variables
-#bank ".data"
+#bank data
 start: #res 1
 start2: #res 1
 mid: #res 1
 end: #res 1
 index: #res 1
-#bank ".instr"
+#bank instr
 
   ;init variable
   st $a start

--- a/MK1_CPU/programs/quick_sort.asm
+++ b/MK1_CPU/programs/quick_sort.asm
@@ -1,11 +1,11 @@
 ;--- quick sort ---
 #include "lib/mk1.cpu"
 
-#bank ".data"
+#bank data
 data: #d8 123, 110, 20, 13, 222, 94, 205, 199, 213, 176, 58, 160, 216, 12, 73, 172, 184, 225, 125, 63, 186, 111, 252, 136, 242, 92, 101, 134, 175, 126, 195, 2, 42, 57, 149, 23, 223, 48, 214, 217
 vector_len = pc - data
 vector: #res vector_len
-#bank ".instr"
+#bank instr
 
 init:
   jal init_display
@@ -60,11 +60,11 @@ quick_sort:
 .return:
   ret
 
-#bank ".data"
+#bank data
 pivot: #res 1
 i: #res 1
 j: #res 1
-#bank ".instr"
+#bank instr
 partition: ;low, high
   mov $a $c ; c = low
   mov $b $a

--- a/MK1_CPU/programs/test_suite.asm
+++ b/MK1_CPU/programs/test_suite.asm
@@ -49,10 +49,10 @@ test_02:
   out 2
 
 ;--- LOAD ---
-#bank ".data"
+#bank data
 variable: #d8 0x55
 variable_location: #d8 variable
-#bank ".instr"
+#bank instr
 test_03:
   ld $a variable
   cmp 0x55
@@ -72,10 +72,10 @@ test_04:
 
 ;--- STORE ---
 
-#bank ".data"
+#bank data
 value = 0x42
 store_variable: #res 1
-#bank ".instr"
+#bank instr
 test_05:
   ldi $a value
   st $a store_variable


### PR DESCRIPTION
List of changes:

- `#bits` in global scope
- `#bankdef` and `#bank` names `".data"`/`".instr"` are now `data`/`instr`
- consistent indenting in `#bankdef`
- nested `#tokendef` is now `#subruledef` in global scope
- `#cpudef` is now `#ruledef`
- token/subrule def `=` is now `=>`
- cup/rule def `->` is now `=>`
- `3'5` constant is now ``5`3`` (https://github.com/hlorenzi/customasm/issues/158)
- `#str` is now `#d`
- customasm submodule is now the upstream main branch current commit

The submodule change abandons your [4 divergent commits](https://github.com/hlorenzi/customasm/compare/main...vascofazza:customasm:master). They might be worth a PR?

resolves #2 